### PR TITLE
Add `ignore_nans` kwarg to metrics.py to produce sensible output when the input image has NaNs

### DIFF
--- a/dm_pix/_src/metrics.py
+++ b/dm_pix/_src/metrics.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 # DO NOT REMOVE - Logging lib.
 
 
-def mae(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Numeric:
+def mae(a: chex.Array, b: chex.Array, *, ignore_nans: bool = False) -> chex.Numeric:
   """Returns the Mean Absolute Error between `a` and `b`.
 
   Args:
@@ -47,7 +47,7 @@ def mae(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Numeric
   return jnp.mean(jnp.abs(a - b), axis=(-3, -2, -1))
 
 
-def mse(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Numeric:
+def mse(a: chex.Array, b: chex.Array, *, ignore_nans: bool = False) -> chex.Numeric:
   """Returns the Mean Squared Error between `a` and `b`.
 
   Args:
@@ -68,7 +68,7 @@ def mse(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Numeric
   return jnp.mean(jnp.square(a - b), axis=(-3, -2, -1))
 
 
-def psnr(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Array:
+def psnr(a: chex.Array, b: chex.Array, *, ignore_nans: bool = False) -> chex.Array:
   """Returns the Peak Signal-to-Noise Ratio between `a` and `b`.
 
   Assumes that the dynamic range of the images (the difference between the
@@ -90,7 +90,7 @@ def psnr(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Array:
   return -10.0 * jnp.log(mse(a, b, ignore_nans=ignore_nans)) / jnp.log(10.0)
 
 
-def rmse(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Array:
+def rmse(a: chex.Array, b: chex.Array, *, ignore_nans: bool = False) -> chex.Array:
   """Returns the Root Mean Squared Error between `a` and `b`.
 
   Args:
@@ -109,7 +109,7 @@ def rmse(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Array:
   return jnp.sqrt(mse(a, b, ignore_nans=ignore_nans))
 
 
-def simse(a: chex.Array, b: chex.Array, ignore_nans: bool = False) -> chex.Array:
+def simse(a: chex.Array, b: chex.Array, *, ignore_nans: bool = False) -> chex.Array:
   """Returns the Scale-Invariant Mean Squared Error between `a` and `b`.
 
   For each image pair, a scaling factor for `b` is computed as the solution to

--- a/dm_pix/_src/metrics_test.py
+++ b/dm_pix/_src/metrics_test.py
@@ -44,7 +44,7 @@ class MSETest(chex.TestCase, absltest.TestCase):
 
   @chex.all_variants
   def test_psnr_match(self):
-    psnr = self.variant(metrics.psnr)
+    psnr = self.variant(functools.partial(metrics.psnr, ignore_nans=False))
     values_jax = psnr(self._img1, self._img2)
     values_tf = tf.image.psnr(self._img1, self._img2, max_val=1.).numpy()
     np.testing.assert_allclose(values_jax, values_tf, rtol=1e-3, atol=1e-3)
@@ -57,7 +57,7 @@ class MSETest(chex.TestCase, absltest.TestCase):
 
   @chex.all_variants
   def test_simse_invariance(self):
-    simse = self.variant(metrics.simse)
+    simse = self.variant(functools.partial(metrics.simse, ignore_nans=False))
     simse_jax = simse(self._img1, self._img1 * 2.0)
     np.testing.assert_allclose(simse_jax, np.zeros(4), rtol=1e-6, atol=1e-6)
 

--- a/dm_pix/_src/metrics_test.py
+++ b/dm_pix/_src/metrics_test.py
@@ -64,7 +64,7 @@ class MSETest(chex.TestCase, absltest.TestCase):
   @chex.all_variants
   def test_simse_ignore_nans(self):
     simse = self.variant(functools.partial(metrics.simse, ignore_nans=True))
-    simse_jax_nan = simse(self._img1.at[:, 0, 0, 0].set(0), self._img1.at[:, 0, 0, 0].set(np.nan))
+    simse_jax_nan = simse(self._img1.at[:, 0, 0, 0].set(np.nan), self._img1.at[:, 0, 0, 0].set(np.nan))
     assert not np.any(np.isnan(simse_jax_nan))
 
 

--- a/dm_pix/_src/metrics_test.py
+++ b/dm_pix/_src/metrics_test.py
@@ -44,7 +44,7 @@ class MSETest(chex.TestCase, absltest.TestCase):
 
   @chex.all_variants
   def test_psnr_match(self):
-    psnr = self.variant(functools.partial(metrics.psnr, ignore_nans=False))
+    psnr = self.variant(metrics.psnr)
     values_jax = psnr(self._img1, self._img2)
     values_tf = tf.image.psnr(self._img1, self._img2, max_val=1.).numpy()
     np.testing.assert_allclose(values_jax, values_tf, rtol=1e-3, atol=1e-3)
@@ -57,7 +57,7 @@ class MSETest(chex.TestCase, absltest.TestCase):
 
   @chex.all_variants
   def test_simse_invariance(self):
-    simse = self.variant(functools.partial(metrics.simse, ignore_nans=False))
+    simse = self.variant(metrics.simse)
     simse_jax = simse(self._img1, self._img1 * 2.0)
     np.testing.assert_allclose(simse_jax, np.zeros(4), rtol=1e-6, atol=1e-6)
 


### PR DESCRIPTION
We've encountered this while working with satellite imagery with a cut-out over the earth -- outer space is represented natively with `np.nan`, and we'd like to compare images using the metrics implemented here.

We've found this fork to be very useful, as it allows us to run the metrics on GPU via JAX without having to re-implement things ourselves, so thought to upstream the changes! Just a couple replacements of `mean`, `sum` with `nanmean`, `nansum` etc in the right places.

Have added some tests that verify that NaNs do not propagate to the output. 