### PR TITLE
Add channel_axis to random_flip_left_right

### DIFF
--- a/dm_pix/_src/augment.py
+++ b/dm_pix/_src/augment.py
@@ -772,6 +772,7 @@ def random_flip_left_right(
     image: chex.Array,
     *,
     probability: chex.Numeric = 0.5,
+    channel_axis: int = -1,
 ) -> chex.Array:
   """Applies `flip_left_right` with a given probability.
 
@@ -781,6 +782,7 @@ def random_flip_left_right(
       ...HWC or ...CHW.
     probability: the probability of applying flip_left_right transform. Must be
       a value in [0, 1].
+    channel_axis: the index of the channel axis.
 
   Returns:
     A left-right flipped image if condition is met, otherwise original image.
@@ -788,7 +790,12 @@ def random_flip_left_right(
   # DO NOT REMOVE - Logging usage.
 
   should_transform = jax.random.bernoulli(key=key, p=probability)
-  return jax.lax.cond(should_transform, flip_left_right, lambda x: x, image)
+  return jax.lax.cond(
+      should_transform,
+      lambda x: flip_left_right(x, channel_axis=channel_axis),
+      lambda x: x,
+      image,
+  )
 
 
 def random_flip_up_down(

--- a/dm_pix/_src/augment_test.py
+++ b/dm_pix/_src/augment_test.py
@@ -188,6 +188,12 @@ class _ImageAugmentationTest(parameterized.TestCase):
         reference_fn=None,
         probability=(0., 1.))
 
+  def test_random_flip_left_right_channel_axis(self):
+    image = jnp.arange(2 * 3 * 4, dtype=jnp.float32).reshape((3, 2, 4))
+    result = augment.random_flip_left_right(
+        jax.random.PRNGKey(0), image, probability=1., channel_axis=0)
+    np.testing.assert_array_equal(result, jnp.flip(image, axis=2))
+
   # Due to a bug in scipy we cannot test all available modes, refer to these
   # issues for more information: https://github.com/jax-ml/jax/issues/11097,
   # https://github.com/jax-ml/jax/issues/11097


### PR DESCRIPTION
## Summary
- add the documented `channel_axis` argument to `random_flip_left_right`
- forward the axis to `flip_left_right`
- add a regression test for channel-first (CHW) images

## Motivation
The deterministic `flip_left_right` API already supports channel-first images through `channel_axis`, but its random wrapper did not expose that argument. This made the random API inconsistent and prevented callers from using HWC/CHW layouts interchangeably.

## Validation
- `python3.12 -m py_compile dm_pix/_src/augment.py dm_pix/_src/augment_test.py`
- `git diff --check`

The full test suite was not run because the local TensorFlow test dependency installation did not complete in this environment.

This PR resolves #111.
