### PR TITLE
Add channel_axis to random_flip_up_down

### DIFF
--- a/dm_pix/_src/augment.py
+++ b/dm_pix/_src/augment.py
@@ -796,6 +796,7 @@ def random_flip_up_down(
     image: chex.Array,
     *,
     probability: chex.Numeric = 0.5,
+    channel_axis: int = -1,
 ) -> chex.Array:
   """Applies `flip_up_down` with a given probability.
 
@@ -805,6 +806,7 @@ def random_flip_up_down(
       ...HWC or ...CHW.
     probability: the probability of applying flip_up_down transform. Must be a
       value in [0, 1].
+    channel_axis: the index of the channel axis.
 
   Returns:
     An up-down flipped image if condition is met, otherwise original image.
@@ -812,7 +814,12 @@ def random_flip_up_down(
   # DO NOT REMOVE - Logging usage.
 
   should_transform = jax.random.bernoulli(key=key, p=probability)
-  return jax.lax.cond(should_transform, flip_up_down, lambda x: x, image)
+  return jax.lax.cond(
+      should_transform,
+      lambda x: flip_up_down(x, channel_axis=channel_axis),
+      lambda x: x,
+      image,
+  )
 
 
 def random_brightness(

--- a/dm_pix/_src/augment_test.py
+++ b/dm_pix/_src/augment_test.py
@@ -188,6 +188,12 @@ class _ImageAugmentationTest(parameterized.TestCase):
         reference_fn=None,
         probability=(0., 1.))
 
+  def test_random_flip_up_down_channel_axis(self):
+    image = jnp.arange(2 * 3 * 4, dtype=jnp.float32).reshape((3, 2, 4))
+    result = augment.random_flip_up_down(
+        jax.random.PRNGKey(0), image, probability=1., channel_axis=0)
+    np.testing.assert_array_equal(result, jnp.flip(image, axis=1))
+
   # Due to a bug in scipy we cannot test all available modes, refer to these
   # issues for more information: https://github.com/jax-ml/jax/issues/11097,
   # https://github.com/jax-ml/jax/issues/11097


### PR DESCRIPTION
## Summary
- add the documented `channel_axis` argument to `random_flip_up_down`
- forward the axis to `flip_up_down`
- add a regression test for channel-first (CHW) images

## Motivation
The deterministic `flip_up_down` API already supports channel-first images through `channel_axis`, but its random wrapper did not expose that argument. This keeps the random and deterministic augmentation APIs consistent and resolves the follow-up requested in issue #117.

## Validation
- `python3.12 -m py_compile dm_pix/_src/augment.py dm_pix/_src/augment_test.py`
- `git diff --check`
